### PR TITLE
Transport certs jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.3-SNAPSHOT] - 2023-01-23
 
+### Changed
+
+ - camel version from 3.18.0 to 3.19.0 (The default TLS protocol is changed from TLSv1.2 to TLSv1.3 in Camel JSSE support)
+
 ### Added
 
  - When requesting DAPS token, transportCertsSha256 from server public key will be sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.3-SNAPSHOT] - 2023-01-23
+
+### Added
+
+ - When requesting DAPS token, transportCertsSha256 from server public key will be sent
+ - Logic for checking TransportCertsSha256 hash value from jwToken
+ - readme file TRANSPORTCERTSSHA256.md with explanation
+ - new property for enabling/disabling new logic for extended token validation 
+ 
+ ```
+ application.extendedTokenValidation=false
+ ```
+
 ## [0.2.2-SNAPSHOT] - 2022-12-29
 
 ### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
  - camel version from 3.18.0 to 3.19.0 (The default TLS protocol is changed from TLSv1.2 to TLSv1.3 in Camel JSSE support)
+ - Multipart message library upgrade from 1.0.14-SNAPSHOT to 1.0.15-SNAPSHOT (memory cleaner in MMP)
 
 ### Added
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,38 @@
 # Start with a base image containing Java runtime
-
-# FROM openjdk:12-jdk-oraclelinux7
-# FROM openjdk:11.0.7-jre
-FROM openjdk:11.0.15-jre
+#FROM ibm-semeru-runtimes:open-11-jre
+#openjdk:21-ea-3-jdk-slim
+FROM eclipse-temurin:11-jre-alpine
 
 # Add Maintainer Info
 LABEL maintainer="gabriele.deluca@eng.it"
 
-# Add a volume pointing to /tmp
-#VOLUME /tmp
+RUN apk add --no-cache wget
+#RUN  apt-get update \
+#  && apt-get install -y wget \
+#  && rm -rf /var/lib/apt/lists/
 
 # Make port 8443 available to the world outside this container
 EXPOSE 8449
 
+RUN mkdir -p /home/nobody/app
+RUN mkdir /var/log/ecc
+WORKDIR /home/nobody
+
 # The application's jar file
-# ARG JAR_FILE=target/*.jar
-COPY target/dependency-jars /run/dependency-jars
+COPY target/dependency-jars /home/nobody/app/dependency-jars
 
 # Add the application's jar to the container
-# ADD ${JAR_FILE} market4.0-execution_core_container_business_logic.jar
-ADD target/application.jar /run/application.jar
+ADD target/application.jar /home/nobody/app/application.jar
+
+RUN chown -R nobody:nogroup /home/nobody
+RUN chown -R nobody:nogroup /var/log/ecc
+
+USER 65534
 
 # Run the jar file
-# ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-cp", "application.jar:/config/", "org.springframework.boot.loader.JarLauncher"]
-ENTRYPOINT java -jar run/application.jar
+ENTRYPOINT java -jar /home/nobody/app/application.jar
 
 #Healthy Status
 HEALTHCHECK --interval=5s --retries=3 --timeout=10s \
 
-#CMD curl http://localhost:8081/about/version || exit 1
-CMD wget -O /dev/null http://localhost:8081/about/version || exit 1
+CMD wget -O /dev/null http://localhost:8081/about/version  || exit 1

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     volumes:
        - ./ecc_resources_provider:/config
        - ./ecc_cert:/cert
+       - ecc_provider_log:/var/log/ecc
     extra_hosts:
       - "ecc-provider:127.0.0.1"
 
@@ -106,6 +107,7 @@ services:
     volumes:
       - ./ecc_resources_consumer:/config
       - ./ecc_cert:/cert
+      - ecc_consumer_log:/var/log/ecc
     extra_hosts:
       - "ecc-consumer:127.0.0.1"
 
@@ -132,3 +134,8 @@ services:
       - ./be-dataapp_resources:/config
       - ./be-dataapp_data_sender:/data
       - ./ecc_cert:/cert
+      
+volumes:
+  ecc_provider_log : {}
+  ecc_consumer_log : {}
+ 

--- a/ci/docker/ecc_resources_consumer/application-docker.properties
+++ b/ci/docker/ecc_resources_consumer/application-docker.properties
@@ -33,6 +33,7 @@ application.websocket.isEnabled=${WS_ECC}
 
 ### DAPS Parameters (for getting token)
 application.isEnabledDapsInteraction=true
+application.extendedTokenValidation=false
 #Cache token(true) or always use new token(false)
 application.tokenCaching=${CACHE_TOKEN}
 #Fetch and cache token on startup. application.tokenCaching must be true!

--- a/ci/docker/ecc_resources_consumer/logback-SENDER.xml
+++ b/ci/docker/ecc_resources_consumer/logback-SENDER.xml
@@ -9,8 +9,9 @@
     </encoder>
   </appender>
 
+	<property name="LOG_DIR" value="/var/log/ecc" />
 	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
-		<file>true_connector_audit_SENDER.log</file>
+		<file>${LOG_DIR}/true_connector_audit_SENDER.log</file>
 		<append>true</append>
 		<encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
 	</appender>

--- a/ci/docker/ecc_resources_provider/application-docker.properties
+++ b/ci/docker/ecc_resources_provider/application-docker.properties
@@ -33,6 +33,7 @@ application.websocket.isEnabled=${WS_ECC}
 
 ### DAPS Parameters (for getting token)
 application.isEnabledDapsInteraction=true
+application.extendedTokenValidation=false
 #Cache token(true) or always use new token(false)
 application.tokenCaching=${CACHE_TOKEN}
 #Fetch and cache token on startup. application.tokenCaching must be true!

--- a/ci/docker/ecc_resources_provider/logback-RECEIVER.xml
+++ b/ci/docker/ecc_resources_provider/logback-RECEIVER.xml
@@ -9,8 +9,9 @@
     </encoder>
   </appender>
 
+	<property name="LOG_DIR" value="/var/log/ecc" />
 	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
-		<file>true_connector_audit_RECEIVER.log</file>
+		<file>${LOG_DIR}/true_connector_audit_RECEIVER.log</file>
 		<append>true</append>
 		<encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
 	</appender>

--- a/doc/TRANSPORTCERTSSHA256.md
+++ b/doc/TRANSPORTCERTSSHA256.md
@@ -1,0 +1,66 @@
+# TransportCertsSha256 JWT validation
+
+
+## jwToken
+
+```
+header:
+{
+  "typ": "at+jwt",
+  "kid": "TCUFeCNazalKHg9KzrzLIAzRWTMDDWSa7LcM9ZwHMyo",
+  "alg": "RS256"
+}
+payload:
+{
+  "aud": "idsc:IDS_CONNECTORS_ALL",
+  "iss": "https://daps.aisec.fraunhofer.de",
+  "sub": "54:3D:3A:3A:FC:DC:05:AB:88:60:9E:60:36:54keyid:CB:8C:C7:B6:85:79:A8:23:A6:CB:15:AB:17:50",
+  "nbf": 1674038398,
+  "iat": 1674038398,
+  "jti": "MTQ4MDUzNTQ0NjQ3OTcxNzcxMjI=",
+  "exp": 1674041998,
+  "client_id": "54:3D:3A:3A:FC:DC:05:AB:88:60:9E:60:36:54keyid:CB:8C:C7:B6:85:79:A8:23:A6:CB:15:AB:17:50",
+  "securityProfile": "idsc:BASE_SECURITY_PROFILE",
+  "referringConnector": "http://ecc-consumer.demo",
+  "@type": "ids:DatPayload",
+  "@context": "https://w3id.org/idsa/contexts/context.jsonld",
+  "transportCertsSha256": "a3cd813e1510ca64a9da****",
+  "scopes": [
+    "idsc:IDS_CONNECTOR_ATTRIBUTES_ALL"
+  ]
+}
+```
+
+## Prerequisite 
+For extended token validation is that **public keys from connector itself and other connectors MUST be loaded into truststore.** Reason for this is that TRUEConnector will:
+ - load all certificates from truststore
+ - generate hash from certificate, using following logic:
+ 
+ ```
+byte[] bytes = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
+digest = Hex.encodeHexString(bytes).toLowerCase();
+```
+ - use certificate's SubjectAlternativeName and populate map with SAN and hash. This map will later be used to perform extended jwToken validation.
+ 
+## Validate jwToken
+
+Once jwToken is received, either from DAPS or from other connector, it will be validated with following:
+
+ - not expired
+ - signature
+ - transportCertsSha256 claim (extended validation)
+ 
+First two checks are mandatory while third one can be switched on or off, depending on property:
+
+```
+application.extendedTokenValidation=true
+```
+ 
+Extended validation will do the following:
+ - get *referringConnector* claim
+ - get *transportCertsSha256*
+ - check if map contains same hash value for referringConnector
+ 
+ If this evaluates as true, token is valid, otherwise, token is not valid.
+ 
+

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<tomcat.version>9.0.24</tomcat.version>
 		<information.model.version>4.1.1</information.model.version>
 		<application.basedir>${basedir}</application.basedir>
-		<multipart.message.processor.version>1.0.14-SNAPSHOT</multipart.message.processor.version>
+		<multipart.message.processor.version>1.0.15-SNAPSHOT</multipart.message.processor.version>
 		<idscp2.libraries.version>0.5.2</idscp2.libraries.version>
 		<jacoco.version>0.8.8</jacoco.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<project.java.version>11</project.java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>it.eng.idsa.businesslogic.Application</start-class>
-		<camel.version>3.18.0</camel.version>
+		<camel.version>3.19.0</camel.version>
 		<tomcat.version>9.0.24</tomcat.version>
 		<information.model.version>4.1.1</information.model.version>
 		<application.basedir>${basedir}</application.basedir>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>it.eng.idsa</groupId>
 	<artifactId>market4.0-execution_core_container_business_logic
 	</artifactId>
-	<version>0.2.2-SNAPSHOT</version>
+	<version>0.2.3-SNAPSHOT</version>
 	<name>market4.0-execution_core_container_business_logic</name>
 	<description>Market4.0 execution core container Business Logic
 	</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.6.RELEASE</version>
+		<version>2.2.11.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>it.eng.idsa</groupId>
@@ -285,7 +285,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.8</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -299,6 +299,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
+	    <version>5.5.7</version>
         </dependency>
 
         <!-- Apache Commons -->
@@ -317,6 +318,7 @@
         <dependency>
             <artifactId>logback-classic</artifactId>
             <groupId>ch.qos.logback</groupId>
+	    <version>1.2.7</version>
         </dependency>
         <dependency>
             <groupId>net.logstash.logback</groupId>
@@ -343,7 +345,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.4.30</version>
+            <version>1.6.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/it/eng/idsa/businesslogic/configuration/OkHttpClientConfiguration.java
+++ b/src/main/java/it/eng/idsa/businesslogic/configuration/OkHttpClientConfiguration.java
@@ -4,6 +4,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.concurrent.TimeUnit;
+import java.util.Collections;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -20,6 +21,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import it.eng.idsa.businesslogic.service.impl.KeystoreProvider;
+import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
 import okhttp3.internal.tls.OkHostnameVerifier;
 
@@ -43,8 +45,8 @@ public class OkHttpClientConfiguration {
 		OkHttpClient client;
 		TrustManager[] trustManagers = null;
 		SSLSocketFactory sslSocketFactory;
-		
 		HostnameVerifier hostnameVerifier;
+
 		if(disableSslVerification) {
 			logger.info("Disabling SSL Validation");
 			hostnameVerifier = new NoopHostnameVerifier();
@@ -58,6 +60,7 @@ public class OkHttpClientConfiguration {
 		}
 		//@formatter:off
 		client = new OkHttpClient.Builder()
+				.connectionSpecs(Collections.singletonList(ConnectionSpec.MODERN_TLS))
 				.connectTimeout(60, TimeUnit.SECONDS)
 		        .writeTimeout(60, TimeUnit.SECONDS)
 		        .readTimeout(60, TimeUnit.SECONDS)
@@ -90,10 +93,12 @@ public class OkHttpClientConfiguration {
 		return trustAllCerts;
 	}
 	
-	private SSLSocketFactory sslSocketFactory(final TrustManager[] trustAllCerts)
+	private SSLSocketFactory sslSocketFactory(final TrustManager[] trustManagers)
 			throws NoSuchAlgorithmException, KeyManagementException {
-		final SSLContext sslContext = SSLContext.getInstance("TLS");
-		sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+		final SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
+		sslContext.init(keystoreProvider.getKeystoreFactory().getKeyManagers(), 
+				trustManagers, 
+				new java.security.SecureRandom());
 		// Create an ssl socket factory with our all-trusting manager
 		final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
 		return sslSocketFactory;

--- a/src/main/java/it/eng/idsa/businesslogic/configuration/SslValidatingConfiguration.java
+++ b/src/main/java/it/eng/idsa/businesslogic/configuration/SslValidatingConfiguration.java
@@ -48,7 +48,7 @@ public class SslValidatingConfiguration {
 	 */
 	private void setTrustStore() throws NoSuchAlgorithmException, KeyManagementException {
 		logger.info("Setting up truststore");
-		SSLContext sslCtx = SSLContext.getInstance("TLS");
+		SSLContext sslCtx = SSLContext.getInstance("TLSv1.3");
 		sslCtx.init(keystoreProvider.getKeystoreFactory().getKeyManagers(), 
 				keystoreProvider.getTrustManagerFactory().getTrustManagers(), 
 				new java.security.SecureRandom());
@@ -75,7 +75,7 @@ public class SslValidatingConfiguration {
 			} };
 
 			// Install the all-trusting trust manager
-			SSLContext sc = SSLContext.getInstance("SSL");
+			SSLContext sc = SSLContext.getInstance("TLS");
 			sc.init(null, trustAllCerts, new java.security.SecureRandom());
 			HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
 

--- a/src/main/java/it/eng/idsa/businesslogic/processor/receiver/ReceiverSendDataToDataAppProcessor.java
+++ b/src/main/java/it/eng/idsa/businesslogic/processor/receiver/ReceiverSendDataToDataAppProcessor.java
@@ -130,7 +130,6 @@ public class ReceiverSendDataToDataAppProcessor implements Processor {
 		exchange.getMessage().setHeaders(headers);
 		
 		if (RouterType.HTTP_HEADER.equals(openDataAppReceiverRouter)) {
-			exchange.getMessage().setBody(responseString);
 			message = httpHeaderService.headersToMessage(headers);
 			
 			Map<String, String> headerHeaderContentType = new HashMap<>();

--- a/src/main/java/it/eng/idsa/businesslogic/service/impl/DapsUtilityProvider.java
+++ b/src/main/java/it/eng/idsa/businesslogic/service/impl/DapsUtilityProvider.java
@@ -3,6 +3,7 @@ package it.eng.idsa.businesslogic.service.impl;
 import java.net.URL;
 import java.nio.file.Path;
 import java.security.PublicKey;
+import java.security.cert.Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
@@ -74,6 +75,10 @@ public class DapsUtilityProvider {
 			logger.error("Token creation error: {}", exception.getMessage());
 		}
 		return jws;
+	}
+	
+	public Certificate getCertificate() {
+		return keystoreProvider.getCertificate();
 	}
 	
 	public PublicKey getPublicKey() {

--- a/src/main/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImpl.java
+++ b/src/main/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImpl.java
@@ -119,12 +119,12 @@ public class DapsV2ServiceImpl implements DapsService {
 		String transportCertsSha256 = jwt.getClaim("transportCertsSha256").asString();
 		if(transportCertsSha256 != null) {
 			logger.info("Single transportCertsSha256");
-			isValid = transportCertsManager.isTransportCertsValid(connectorId, transportCertsSha256);
+			isValid = transportCertsManager.isTransportCertValid(connectorId, transportCertsSha256);
 		} else {
 			logger.info("Multiple transportCertsSha256");
 			String[] transportCerts = jwt.getClaim("transportCertsSha256").asArray(String.class);
 			for (String transportCert : transportCerts) {
-				if(transportCertsManager.isTransportCertsValid(connectorId, transportCert)) {
+				if(transportCertsManager.isTransportCertValid(connectorId, transportCert)) {
 					isValid = true;
 					transportCertsSha256 = transportCert;
 					break;
@@ -218,16 +218,9 @@ public class DapsV2ServiceImpl implements DapsService {
 	}
 
 	private String createCertsShaClaim() {
-//		{
-//		    "access_token": {
-//		        "transportCertsSha256": {
-//		            "value": ["ksjdhvs87h3w4fjhsf87hkjvs", "qz47djs87h3w4fjhsf87hg57d"]
-//		        }
-//		    }
-//		}
 		JSONArray transportCertsJsonArray = new JSONArray();
 		transportCertsJsonArray.put(transportCertsManager.getCertificateDigest(dapsUtilityProvider.getCertificate()));
-		transportCertsJsonArray.put(transportCertsManager.getConnectorTransportCetsSHa());
+		transportCertsJsonArray.put(transportCertsManager.getConnectorTransportCertsSha());
 		
 		return new JSONObject()
 	        .put("access_token", new JSONObject().put("transportCertsSha256", new JSONObject().put("value", transportCertsJsonArray)))

--- a/src/main/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImpl.java
+++ b/src/main/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImpl.java
@@ -10,6 +10,7 @@ import java.security.cert.CertificateException;
 import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -224,11 +225,12 @@ public class DapsV2ServiceImpl implements DapsService {
 //		        }
 //		    }
 //		}
-//		JSONArray jsonArray = new JSONArray();
-//		jsonArray.put("IGOR");
-//		jsonArray.put(transportCertsManager.getConnectorTransportCetsSHa());
+		JSONArray transportCertsJsonArray = new JSONArray();
+		transportCertsJsonArray.put(transportCertsManager.getCertificateDigest(dapsUtilityProvider.getCertificate()));
+		transportCertsJsonArray.put(transportCertsManager.getConnectorTransportCetsSHa());
+		
 		return new JSONObject()
-	        .put("access_token", new JSONObject().put("transportCertsSha256", new JSONObject().put("value", transportCertsManager.getConnectorTransportCetsSHa())))
+	        .put("access_token", new JSONObject().put("transportCertsSha256", new JSONObject().put("value", transportCertsJsonArray)))
 	        .toString();
 	}
 }

--- a/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
+++ b/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
@@ -1,0 +1,122 @@
+package it.eng.idsa.businesslogic.service.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TransportCertsManager {
+
+	private static final Logger logger = LoggerFactory.getLogger(TransportCertsManager.class);
+
+	private Map<String, String> transportCerts;
+	private String connectorTransportCertSha;
+
+	public TransportCertsManager(@Value("${server.ssl.key-store}") String sslKeystore,
+			@Value("${server.ssl.key-store-password}") String sslPassword,
+			@Value("${server.ssl.key-alias}") String sslAlias,
+			@Value("${application.targetDirectory}") Path targetDirectory,
+			@Value("${application.trustStoreName}") String trustStoreName,
+			@Value("${application.trustStorePassword}") String trustStorePwd)
+			throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+		InputStream jksTrustStoreInputStream = null;
+		KeyStore trustManagerKeyStore;
+		try {
+			if (StringUtils.isNotBlank(trustStoreName)) {
+				logger.info("TransportCerts manager initialization");
+				jksTrustStoreInputStream = Files.newInputStream(targetDirectory.resolve(trustStoreName));
+				trustManagerKeyStore = KeyStore.getInstance("JKS");
+				trustManagerKeyStore.load(jksTrustStoreInputStream, trustStorePwd.toCharArray());
+				populateTransportCertsSha256(trustManagerKeyStore);
+				this.connectorTransportCertSha = getConnectorTransportCertSha256(sslKeystore, sslPassword, sslAlias);
+			} else {
+				logger.info("Truststore not configured, cannot calculate TransportCertsSha256");
+			}
+		} finally {
+			if (jksTrustStoreInputStream != null) {
+				jksTrustStoreInputStream.close();
+			}
+		}
+	}
+
+	public String getConnectorTransportCetsSHa() {
+		return this.connectorTransportCertSha;
+	}
+
+	public boolean isTransportCertsValid(String connectorId, String transportCert) {
+		logger.info("Validating transportCertSha256 '{}' for connector with id {}", transportCert, connectorId);
+		return transportCert.equals(transportCerts.get(connectorId));
+	}
+
+	private void populateTransportCertsSha256(KeyStore trustManagerKeyStore) throws KeyStoreException {
+		logger.info("Calculating TransportCertsSha256 from configured truststore");
+		transportCerts = new HashMap<>();
+		List<String> aliases = Collections.list(trustManagerKeyStore.aliases());
+		aliases.forEach(a -> {
+			try {
+				X509Certificate x509Cert = (X509Certificate) trustManagerKeyStore.getCertificate(a);
+				x509Cert.getSubjectAlternativeNames().stream()
+						.forEach(san -> transportCerts.put((String) san.get(1), getCertificateDigest(x509Cert)));
+			} catch (KeyStoreException | CertificateParsingException e) {
+				logger.error("Error while calculating TransportCertsSha256", e);
+			}
+		});
+		transportCerts.remove("localhost");
+		logger.info("Calculated {} transportCertsSha256 values", transportCerts.entrySet().size());
+		if (logger.isDebugEnabled()) {
+			transportCerts.keySet().stream().forEach(k -> logger.debug(k + " : " + transportCerts.get(k)));
+		}
+	}
+
+	private String getCertificateDigest(Certificate cert) {
+		String digest = null;
+		try {
+			byte[] bytes = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
+			digest = Hex.encodeHexString(bytes).toLowerCase();
+		} catch (CertificateEncodingException | NoSuchAlgorithmException e) {
+			logger.error("Error while trying to load certificate", e);
+		}
+		return digest;
+	}
+
+	private String getConnectorTransportCertSha256(String sslKeystore, String sslPassword, String sslAlias) {
+		return getCertificateDigest(getCertificateTLS(sslKeystore, sslPassword, sslAlias));
+	}
+
+	private X509Certificate getCertificateTLS(String sslKeystore, String sslPassword, String sslAlias) {
+		Path path = Paths.get(sslKeystore);
+		KeyStore keystore;
+		try {
+			InputStream jksKeyStoreInputStream = Files.newInputStream(path);
+			keystore = KeyStore.getInstance("JKS");
+			keystore.load(jksKeyStoreInputStream, sslPassword.toCharArray());
+			return (X509Certificate) keystore.getCertificate(sslAlias);
+		} catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+			logger.error("Error while trying to read server certificate", e);
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
+++ b/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
@@ -25,6 +25,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+/**
+ * Reads certificate from truststore, </br>
+ * calculates SHA256 using MessageDigest.getInstance("SHA-256").digest(cert.getEncoded())</br>
+ * creates map with certificate SubjectAlternativeName and calculated SHA256</br>
+ * 
+ * Map is later used to verify if jwt.transportCertSha256 matches with the one from truststore
+ * 
+ * @author igor.balog
+ *
+ */
 @Component
 public class TransportCertsManager {
 
@@ -48,7 +58,7 @@ public class TransportCertsManager {
 				jksTrustStoreInputStream = Files.newInputStream(targetDirectory.resolve(trustStoreName));
 				trustManagerKeyStore = KeyStore.getInstance("JKS");
 				trustManagerKeyStore.load(jksTrustStoreInputStream, trustStorePwd.toCharArray());
-				populateTransportCertsSha256(trustManagerKeyStore);
+				populateTransportCertsSha(trustManagerKeyStore);
 				this.connectorTransportCertSha = getConnectorTransportCertSha256(targetDirectory, sslKeystore, sslPassword, sslAlias);
 			} else {
 				logger.info("Truststore not configured, cannot calculate TransportCertsSha256");
@@ -60,16 +70,16 @@ public class TransportCertsManager {
 		}
 	}
 
-	public String getConnectorTransportCetsSHa() {
+	public String getConnectorTransportCertsSha() {
 		return this.connectorTransportCertSha;
 	}
 
-	public boolean isTransportCertsValid(String connectorId, String transportCert) {
+	public boolean isTransportCertValid(String connectorId, String transportCert) {
 		logger.info("Validating transportCertSha256 '{}' for connector with id {}", transportCert, connectorId);
 		return transportCert.equals(transportCerts.get(connectorId));
 	}
 
-	private void populateTransportCertsSha256(KeyStore trustManagerKeyStore) throws KeyStoreException {
+	private void populateTransportCertsSha(KeyStore trustManagerKeyStore) throws KeyStoreException {
 		logger.info("Calculating TransportCertsSha256 from configured truststore");
 		transportCerts = new HashMap<>();
 		List<String> aliases = Collections.list(trustManagerKeyStore.aliases());

--- a/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
+++ b/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
@@ -91,7 +91,7 @@ public class TransportCertsManager {
 		}
 	}
 
-	private String getCertificateDigest(Certificate cert) {
+	public String getCertificateDigest(Certificate cert) {
 		String digest = null;
 		try {
 			byte[] bytes = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());

--- a/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
+++ b/src/main/java/it/eng/idsa/businesslogic/service/impl/TransportCertsManager.java
@@ -76,8 +76,10 @@ public class TransportCertsManager {
 		aliases.forEach(a -> {
 			try {
 				X509Certificate x509Cert = (X509Certificate) trustManagerKeyStore.getCertificate(a);
-				x509Cert.getSubjectAlternativeNames().stream()
-						.forEach(san -> transportCerts.put((String) san.get(1), getCertificateDigest(x509Cert)));
+				if(x509Cert.getSubjectAlternativeNames() != null) {
+					x509Cert.getSubjectAlternativeNames().stream()
+					.forEach(san -> transportCerts.put((String) san.get(1), getCertificateDigest(x509Cert)));
+				}
 			} catch (KeyStoreException | CertificateParsingException e) {
 				logger.error("Error while calculating TransportCertsSha256", e);
 			}

--- a/src/main/resources/application-RECEIVER.properties
+++ b/src/main/resources/application-RECEIVER.properties
@@ -43,6 +43,7 @@ application.validateProtocol=true
 
 ### DAPS Parameters (for getting token)
 application.isEnabledDapsInteraction=true
+application.extendedTokenValidation=false
 #Cache token(true) or always use new token(false)
 application.tokenCaching=true
 #Fetch and cache token on startup. application.tokenCaching must be true!

--- a/src/main/resources/application-SENDER.properties
+++ b/src/main/resources/application-SENDER.properties
@@ -43,6 +43,7 @@ application.validateProtocol=true
 
 ### DAPS Parameters (for getting token)
 application.isEnabledDapsInteraction=true
+application.extendedTokenValidation=false
 #Cache token(true) or always use new token(false)
 application.tokenCaching=true
 #Fetch and cache token on startup. application.tokenCaching must be true!

--- a/src/test/java/it/eng/idsa/businesslogic/processor/receiver/ReceiverSendDataToDataAppProcessorTest.java
+++ b/src/test/java/it/eng/idsa/businesslogic/processor/receiver/ReceiverSendDataToDataAppProcessorTest.java
@@ -104,7 +104,7 @@ public class ReceiverSendDataToDataAppProcessorTest {
 	}
 	
 	@Test
-	public void processHttpHeadermSuccess() throws Exception {
+	public void processHttpHeaderSuccess() throws Exception {
 		ReflectionTestUtils.setField(processor, "openDataAppReceiverRouter", "http-header", String.class);
 		RequestBody mixRequestBody = RequestResponseUtil.createRequestBody("PAYLOAD");
 		var multipartMessage = MultipartMessageUtil.getMultipartMessage();

--- a/src/test/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImplTest.java
+++ b/src/test/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImplTest.java
@@ -49,6 +49,8 @@ public class DapsV2ServiceImplTest {
 	@Mock
     private DapsUtilityProvider dapsUtilityProvider;
 	@Mock
+	private TransportCertsManager transportCertsManager;
+	@Mock
 	private OkHttpClient client;
 	@Mock
 	private Call call;
@@ -59,6 +61,7 @@ public class DapsV2ServiceImplTest {
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		when(dapsUtilityProvider.getDapsV2Jws()).thenReturn(jws);
+		when(transportCertsManager.getConnectorTransportCetsSHa()).thenReturn("TOKEN_HASHED_VALUE");
 		ReflectionTestUtils.setField(dapsV2Service, "dapsUrl", dapsUrl);
 	}
 	

--- a/src/test/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImplTest.java
+++ b/src/test/java/it/eng/idsa/businesslogic/service/impl/DapsV2ServiceImplTest.java
@@ -61,7 +61,7 @@ public class DapsV2ServiceImplTest {
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		when(dapsUtilityProvider.getDapsV2Jws()).thenReturn(jws);
-		when(transportCertsManager.getConnectorTransportCetsSHa()).thenReturn("TOKEN_HASHED_VALUE");
+		when(transportCertsManager.getConnectorTransportCertsSha()).thenReturn("TOKEN_HASHED_VALUE");
 		ReflectionTestUtils.setField(dapsV2Service, "dapsUrl", dapsUrl);
 	}
 	

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -60,7 +60,6 @@ application.fetchTokenOnStartup=false
 application.daps.orbiter.privateKey=
 application.daps.orbiter.password=
 application.dapsVersion=orbiter
-#application.targetDirectory=./src/test/resources/
 application.targetDirectory=classpath:
 application.dapsUrl=
 application.keyStoreName=ssl-server.jks

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,7 +10,9 @@ server.max-http-header-size=15360
 server.ssl.key-alias=execution-core-container
 server.ssl.key-password=changeit
 #server.ssl.key-store=./src/test/resources/ssl-server.jks
-server.ssl.key-store=ssl-server.jks
+application.ssl.key-store.name=ssl-server.jks
+application.ssl.key-store-password=changeit
+server.ssl.key-store=${application.ssl.key-store.name}
 server.ssl.key-store-provider=SUN
 server.ssl.key-store-type=JKS
 server.ssl.SHA256=AC3BCAED1F01C63E18D4E0994C48D18EB6F79D01844564A4BA8476BE2D17F5E4
@@ -49,6 +51,7 @@ application.password.validator.minSpecial=1
 
 ### DAPS Parameters (for getting token)
 application.isEnabledDapsInteraction=true
+application.extendedTokenValidation=false
 #Cache token(true) or always use new token(false)
 application.tokenCaching=false
 #Fetch and cache token on startup. application.tokenCaching must be true!
@@ -57,6 +60,7 @@ application.fetchTokenOnStartup=false
 application.daps.orbiter.privateKey=
 application.daps.orbiter.password=
 application.dapsVersion=orbiter
+#application.targetDirectory=./src/test/resources/
 application.targetDirectory=classpath:
 application.dapsUrl=
 application.keyStoreName=ssl-server.jks


### PR DESCRIPTION
Added logic for including ssl-server hash in jwt
TransportCertsManager for comparing referringConnector from jwt with SubjectAlternativeName from certificates from trustStore
new property application.extendedTokenValidation=false for enabling/disabling extended jwt validation